### PR TITLE
Tool: switch to 'default' layout for chapter landing pages

### DIFF
--- a/admin/readme.md
+++ b/admin/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Organisatorisches"
 
 hidden: true

--- a/homework/readme.md
+++ b/homework/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Praktikum/Übung"
 
 hidden: true

--- a/lecture/csp/readme.md
+++ b/lecture/csp/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Constraintsolving"
 menuTitle: "CSP"
 ---

--- a/lecture/dtl/readme.md
+++ b/lecture/dtl/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Entscheidungsbäume"
 ---
 

--- a/lecture/ea/readme.md
+++ b/lecture/ea/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Genetische Algorithmen"
 ---
 

--- a/lecture/games/readme.md
+++ b/lecture/games/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Spiele"
 ---
 

--- a/lecture/intro/readme.md
+++ b/lecture/intro/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Einführung KI"
 ---
 

--- a/lecture/logic/readme.md
+++ b/lecture/logic/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Logik"
 menuTitle: "Logik"
 ---

--- a/lecture/naivebayes/readme.md
+++ b/lecture/naivebayes/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Naive Bayes"
 ---
 

--- a/lecture/nn/readme.md
+++ b/lecture/nn/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "NN: Einführung in Neuronale Netze"
 menuTitle: "Neuronale Netze"
 ---

--- a/lecture/readme.md
+++ b/lecture/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Vorlesungsunterlagen"
 menutitle: "Vorlesung"
 ---

--- a/lecture/search/informed/readme.md
+++ b/lecture/search/informed/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Informierte Suche"
 ---
 

--- a/lecture/search/local/readme.md
+++ b/lecture/search/local/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Lokale Suche"
 ---
 

--- a/lecture/search/readme.md
+++ b/lecture/search/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Suche"
 ---
 

--- a/lecture/search/uninformed/readme.md
+++ b/lecture/search/uninformed/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Uninformierte Suche"
 ---
 


### PR DESCRIPTION
Das `chapter`-Template ist irgendwie kaputt: Die Fußzeile wird viel zu groß dargestellt. Das betrifft auch das originale `chapter`-Template ... Wir wechseln hier auf das `default`-Template, wodurch die Fußzeile wieder passt. Einzig der `<hr>` unter dem Titel fehlt ...