### PR TITLE
Orga: remove edit-url from hugo-conf

### DIFF
--- a/hugo_conf.yaml
+++ b/hugo_conf.yaml
@@ -16,7 +16,6 @@ theme:
 #publishDir: "docs"  ## set via Makefile: $(WEB_OUTPUT_DIR)
 
 params:
-#  editURL: "https://github.com/Artificial-Intelligence-HSBI-TDU/KI-Vorlesung/edit/master/lecture/"
   author: "cagix"
   titleSeparator: " "
   alwaysopen: false


### PR DESCRIPTION
We provide the folder structure for Hugo programmatically, thus the use of the edit-url would point to a temporary file (name), which would not be available in the repo ...