### PR TITLE
Lecture: replace link to ipynb

### DIFF
--- a/lecture/nn/nn2_linear_regression.md
+++ b/lecture/nn/nn2_linear_regression.md
@@ -47,7 +47,7 @@ challenges: |
     Wie kann die Merkmalskalierung dem genannten Nachteil entgegenwirken?
     *   Zeigen Sie unter Verwendung Ihrer eigenen, zufällig generierten Datenpunkte aus dem Bereich 
     $[100, 300] \times [0, 2]$, wie sich Standardisierung, Min-Max Skalierung und Normalisierung auf die Daten auswirken.
-    Vergleichen Sie dazu die jeweiligen Streudiagramme (scatterplots). Sie können hierzu das folgende [**Jupyter Notebook**](https://raw.githubusercontent.com/Artificial-Intelligence-HSBI-TDU/KI-Vorlesung/master/lecture/nn/files/Feature_Scaling_Starter.ipynb) als Startpunkt benutzen.
+    Vergleichen Sie dazu die jeweiligen Streudiagramme (scatterplots). Sie können hierzu das folgende [**Jupyter Notebook**](https://github.com/Artificial-Intelligence-HSBI-TDU/KI-Vorlesung/blob/master/lecture/nn/files/Feature_Scaling_Starter.ipynb) als Startpunkt benutzen.
 ---
 
 


### PR DESCRIPTION
In our challenges, resolving the images and attachments doesn't work properly. For this reason, we have to use instead of local links here the links in the GitHub repo. 

In order for the images to be resolved correctly, we need the "raw" URL here: The image should be embedded as such in the website - the "normal" URL however is the preview on GitHub. For other files, we should use the "normal" URL so that the preview is displayed.