### PR TITLE
Homework: move intro task as bonus to perceptron homework

### DIFF
--- a/homework/sheet-nn-perceptron.md
+++ b/homework/sheet-nn-perceptron.md
@@ -9,6 +9,18 @@ hidden: true
 
 
 
+## Bonus: Möglichkeiten und Grenzen sowie Auswirkungen der KI (2P)
+
+Recherchieren Sie, welche Probleme bereits mittels Computer- bzw. Robotereinsatz
+gelöst werden können und welche aktuell noch ungelöst sind.
+
+Recherchieren Sie Auswirkungen auf die Gesellschaft durch die KI, etwa
+durch autonomes Fahren oder durch _Large Language Models_ (LLM).
+
+*Thema*: Gefühl für bereits realisierbare Aufgaben, Chancen und Risiken, Ethik
+
+
+
 ## NN.Perzeptron.01: Entscheidungsgrenze (2P)
 
 *   (1P) Betrachten Sie das durch den Gewichtsvektor $(w_0,w_1,w_2)^T = (2,1,1)^T$ gegebene Perzeptron. Zeichnen Sie die Trennebene und markieren Sie den Bereich, der mit $+1$ klassifiziert wird.

--- a/homework/sheet-search.md
+++ b/homework/sheet-search.md
@@ -9,25 +9,7 @@ hidden: true
 
 
 
-## Search.01: Möglichkeiten und Grenzen der KI (1P)
-
-Recherchieren Sie, welche Probleme bereits mittels Computer- bzw. Robotereinsatz
-gelöst werden können und welche aktuell noch ungelöst sind.
-
-*Thema*: Gefühl für bereits realisierbare Aufgaben
-
-
-
-## Search.02: Auswirkungen der KI (1P)
-
-Recherchieren Sie Auswirkungen auf die Gesellschaft durch die KI, etwa
-durch autonomes Fahren oder durch _Large Language Models_ (LLM).
-
-*Thema*: Chancen und Risiken, Ethik
-
-
-
-## Search.03: Problemformalisierung, Zustandsraum (2P)
+## Search.01: Problemformalisierung, Zustandsraum (3P)
 
 Drei Elben und drei Orks befinden sich an einem Ufer eines Flusses und wollen
 diesen überqueren. Es steht dazu ein Pferd zur Verfügung, welches maximal zwei
@@ -45,7 +27,7 @@ zwischen beiden Gruppen kommt.
 
 
 
-## Search.04: Suchverfahren (4P)
+## Search.02: Suchverfahren (5P)
 
 Betrachten Sie folgende Landkarte und Restwegschätzungen:
 
@@ -68,7 +50,7 @@ Betrachten Sie folgende Landkarte und Restwegschätzungen:
     gern auch die Java-Klassen im Paket [`aima.core.search`] bzw. die Python-Klassen in [`search.py`]
     als Ausgangspunkt nutzen.[^aima]
 
-2.  Dürfen die oben gegebenen Restkostenabschätzungen in A\* verwendet werden?
+2.  Dürfen die oben gegebenen Restkostenabschätzungen in A\* verwendet werden? (1P)
     *   Falls ja, warum?
     *   Falls nein, warum? Wie müssten die Abschätzungen ggf. korrigiert werden?
 
@@ -84,7 +66,7 @@ vor München, Karlsruhe vor Kassel etc.
 
 
 
-## Search.05: Dominanz (1P)
+## Search.03: Dominanz (1P)
 
 Was bedeutet *"Eine Heuristik $h_1(n)$ dominiert eine Heuristik $h_2(n)$"*?
 
@@ -98,31 +80,9 @@ Geben Sie selbstgewählte Beispiele an.
 
 
 
-## Search.06: Beweis der Optimalität von A* (1P)
+## Search.04: Beweis der Optimalität von A\* (1P)
 
-Beweisen Sie, dass A* in der Tree-Search-Variante bei Nutzung einer
+Beweisen Sie, dass A\* in der Tree-Search-Variante bei Nutzung einer
 zulässigen Heuristik optimal ist.
 
 *Thema*: Bedeutung einer zulässigen Heuristik (Selbststudium)
-
-
-
-## Search.07 Bonus: Turing Test (1P)
-
-Testen Sie einige der im Netz verfügbaren Chatbots auf deren Intelligenz.[^Links]
-
-Notieren Sie sich eine Startfrage und messen Sie die Zeit, die Sie bei den
-verschiedenen Programmen benötigen, bis Sie sicher sagen können, dass es kein
-Mensch ist. Speichern Sie jeweils ein Protokoll der Dialoge. Können Sie selbst
-einen Bot erstellen?
-
-Vergleichen Sie dabei traditionelle Chatbots und LLM.
-
-*Thema*: Turing-Test selbst erfahren
-
-[^Links]: Starten Sie zum Beispiel auf
-[github.com/DopplerHQ/awesome-bots](https://github.com/DopplerHQ/awesome-bots#popular-examples-of-bots)
-oder [simonlaven.com](https://www.simonlaven.com/)
-oder [cleverbot.com/](https://www.cleverbot.com/)
-oder [home.pandorabots.com](https://home.pandorabots.com/en/)
-oder [github.com/alice-bot](https://github.com/alice-bot).


### PR DESCRIPTION
Da im W24 der Start bei NN liegt, ist das Blatt zur Suche irgendwann mitten im Semester dran. Dann machen die Aufgaben zur Einführung nicht mehr so richtig Sinn.

1. Schiebe die Diskussion zu Möglichkeiten&Grenzen sowie Auswirkungen der KI auf das erste Blatt (Perzeptron). Bonus-Aufgabe, damit die Punkte nicht angepasst werden müssen.
2. Entferne die restlichen Einführungsaufgaben vom Suche-Blatt.
3. Passe die Punkte auf dem Suche-Blatt an.